### PR TITLE
Show error message on error

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -43,7 +43,7 @@
       <div>
         <button id="b-entername">Go</button>
       </div>
-      <div id="nameerror" class="errorbox"></div>
+      <div id="nameerror" class="errorbox" hidden></div>
     </div>
 
     <main id="interface" hidden>
@@ -69,7 +69,7 @@
         <div id="tab-queuesong">
           <input id="input-songurl" type="text" autocomplete="url" placeholder="Place a song url here..." />
           <button id="b-songurl">Queue</button>
-          <span id="error" class="errorbox">There was an error!</span>
+          <span id="error" class="errorbox" hidden>There was an error!</span>
         </div>
 
         <div id="tab-settings" hidden>

--- a/dist/static/site.css
+++ b/dist/static/site.css
@@ -319,7 +319,6 @@ main {
 
 .errorbox {
   color: #d93434;
-  display: none;
   cursor: pointer;
 }
 

--- a/dist/static/site.js
+++ b/dist/static/site.js
@@ -156,8 +156,8 @@ window.onload = () => {
   setInterval(heartbeat, 15000);
 
   // make error messages disappear when we click on them
-  document.getElementById('error').onclick = (event) => { event.target.hidden = false; };
-  document.getElementById('nameerror').onclick = (event) => { event.target.hidden = false; };
+  document.getElementById('error').onclick = (event) => { event.target.hidden = true; };
+  document.getElementById('nameerror').onclick = (event) => { event.target.hidden = true; };
 
   document.getElementById('b-entername').onclick = submitName;
   document.getElementById('b-songurl').onclick = submitSong;


### PR DESCRIPTION
At the moment, when an error occurs (like an invalid name), the message is not displayed in the UI because of a CSS conflict.

Since the class `.errorbox` has the `display: hidden` property, when you set `hidden="false"` on the element it doesn't actually display the element since it's overridden by the `display: hidden`.

This PR removes the `display: hidden`  from `.errorbox` and applies the `hidden` attribute manually to all error boxes.